### PR TITLE
Add support for DocumentFragment as input for renderer

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -10,9 +10,10 @@ var CustomElements = require('./custom-elements');
 function isElement(o) {
   return (
     typeof HTMLElement === 'object' ?
-      o instanceof HTMLElement || s instanceof DocumentFragment : //DOM2
-      o && typeof o === 'object' && o !== null && (o.nodeType === 1 || o.nodeType === 11) &&
-      typeof o.nodeName === 'string'
+      o instanceof HTMLElement || o instanceof DocumentFragment : //DOM2
+      o && typeof o === 'object' && o !== null &&
+        (o.nodeType === 1 || o.nodeType === 11) &&
+        typeof o.nodeName === 'string'
   );
 }
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -10,8 +10,8 @@ var CustomElements = require('./custom-elements');
 function isElement(o) {
   return (
     typeof HTMLElement === 'object' ?
-      o instanceof HTMLElement : //DOM2
-      o && typeof o === 'object' && o !== null && o.nodeType === 1 &&
+      o instanceof HTMLElement || s instanceof DocumentFragment : //DOM2
+      o && typeof o === 'object' && o !== null && (o.nodeType === 1 || o.nodeType === 11) &&
       typeof o.nodeName === 'string'
   );
 }

--- a/test/phantomjs/renderer.js
+++ b/test/phantomjs/renderer.js
@@ -43,6 +43,13 @@ describe('DOM Rendering', function () {
         Cycle.createRenderer(element);
       });
     });
+    
+    it('should accept a DocumentFragment as input', function () {
+      var element = document.createDocumentFragment();
+      assert.doesNotThrow(function () {
+        Cycle.createRenderer(element);
+      });
+    });
 
     it('should accept a string selector to an existing element as input', function () {
       var id = 'testShouldAcceptSelectorToExisting';
@@ -54,6 +61,7 @@ describe('DOM Rendering', function () {
         Cycle.createRenderer('#' + id);
       });
     });
+    
 
     it('should not accept a selector to an unknown element as input', function () {
       assert.throws(function () {


### PR DESCRIPTION
Currently it's impossible to use Cycle.js with custom elements and Shadow DOM, because shadowRoot is DocumentFragment, not HTMLElement. As far as I see, virtual-dom package works fine with DocumentFragment too, so I see no reason to prevent usage of it in Cycle.