### PR TITLE
nostream: Always subscribe rootElem$ for better error handling

### DIFF
--- a/src/custom-element-widget.js
+++ b/src/custom-element-widget.js
@@ -110,14 +110,18 @@ function makeInit(tagName, definitionFn) {
     let widget = this;
     let element = createContainerElement(tagName, widget.properties);
     let propertiesProxy = makePropertiesProxy();
-    let domUI = applyToDOM(element, definitionFn, propertiesProxy);
+    let domUI = applyToDOM(
+      element,
+      definitionFn,
+      widget.rootElem$.asObserver(),
+      propertiesProxy
+    );
     element.cycleCustomElementMetadata = {
       propertiesProxy,
       rootElem$: domUI.rootElem$,
       customEvents: domUI.customEvents,
       eventDispatchingSubscription: false
     };
-    domUI.rootElem$.subscribe(widget.rootElem$.asObserver());
     element.eventDispatchingSubscription = subscribeDispatchers(element);
     subscribeDispatchersWhenRootChanges(element.cycleCustomElementMetadata);
     widget.update(null, element);

--- a/test/browser/custom-elements.js
+++ b/test/browser/custom-elements.js
@@ -223,7 +223,7 @@ describe('Custom Elements', function () {
       };
     });
     // Make VNode with a string as child
-    let vtree$ = Rx.Observable.just(h('myelement'));
+    let vtree$ = Rx.Observable.just(h('div', h('myelement')));
     let domUI = Cycle.applyToDOM(createRenderTarget(), () => vtree$);
     console = realConsole;
     assert.strictEqual(warnMessages.length, 1);
@@ -332,15 +332,19 @@ describe('Custom Elements', function () {
     let vtree$ = Rx.Observable.just(h('div.toplevel', [
       h('myelement', {children: 123})
     ]));
-    let domUI = Cycle.applyToDOM(createRenderTarget(), () => vtree$);
-    domUI.rootElem$.subscribe(() => {}, function (err) {
-      assert.strictEqual(err.message, 'Custom element should not have property ' +
-        '`children`. This is reserved for children elements nested into this ' +
-        'custom element.'
-      );
-      domUI.dispose();
-      done();
-    });
+    let observer = Rx.Observer.create(
+      () => {},
+      (err) => {
+        assert.strictEqual(err.message, 'Custom element should not have property ' +
+          '`children`. This is reserved for children elements nested into this ' +
+          'custom element.'
+        );
+        // TODO: cannot dispose because applyToDOM has not yet completed.
+        // domUI.dispose();
+        done();
+      }
+    );
+    let domUI = Cycle.applyToDOM(createRenderTarget(), () => vtree$, observer);
   });
 
   it('should recognize changes on a mutable collection given as props', function (done) {

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -152,14 +152,17 @@ describe('Rendering', function () {
       Cycle.registerCustomElement('myelement', Fixture89.myelement);
       let number$ = Fixture89.makeModelNumber$();
       let vtree$ = Fixture89.viewWithoutContainerFn(number$);
-      let domUI = Cycle.applyToDOM(createRenderTarget(), () => vtree$);
-
-      domUI.rootElem$.subscribe(() => {}, (err) => {
-        let errMsg = 'Illegal to use a Cycle custom element as the root of a View.';
-        assert.strictEqual(err.message, errMsg);
-        domUI.dispose();
-        done();
-      });
+      let observer = Rx.Observer.create(
+        () => {},
+        (err) => {
+          let errMsg = 'Illegal to use a Cycle custom element as the root of a View.';
+          assert.strictEqual(err.message, errMsg);
+          // TODO: cannot dispose because applyToDOM has not yet completed.
+          // domUI.dispose();
+          done();
+        }
+      );
+      let domUI = Cycle.applyToDOM(createRenderTarget(), () => vtree$, observer);
     });
   });
 });


### PR DESCRIPTION
Diff at test/browser/custom-elements.js:L226 shows exception could be silently thrown even if the element was actually rendered. I think this is a drawback developers would encounter often.

And this shows we might need a additional parameter for skip the rendering in applyToDOM and another `subscribe` method for doing `rootElem$.connect()` and `rootElem$.subscribe()`.

```
// TODO: cannot dispose because applyToDOM has not yet completed.
```

The above todo comment in the test shows that subscribe method is necessary for properly disposing domUI after this change was made.