### PR TITLE
nostream: Properly dispose resources after the custom-element has been destroyed

### DIFF
--- a/src/custom-elements.js
+++ b/src/custom-elements.js
@@ -41,6 +41,7 @@ function registerCustomElement(tagName, definitionFn) {
   WidgetClass.definitionFn = definitionFn;
   WidgetClass.prototype.init = CustomElementWidget.makeInit(tagName, definitionFn);
   WidgetClass.prototype.update = CustomElementWidget.makeUpdate();
+  WidgetClass.prototype.destroy = CustomElementWidget.makeDestroy();
   CustomElementsRegistry.set(tagName, WidgetClass);
 }
 


### PR DESCRIPTION
This is a retry of #111. All test passed. `synthetic-examples/nested-custom` has been tested and no problem found. The test for that example has not yet been written in this PR, however.